### PR TITLE
Fix to support connection storage in Database Connector connectionDetails object

### DIFF
--- a/R/SelfControlledCohort.R
+++ b/R/SelfControlledCohort.R
@@ -218,11 +218,18 @@ runSelfControlledCohort <- function(connectionDetails,
     outcomePersonId <- "subject_id"
   }
 
+  closeConnection <- FALSE
   # Check if connection already open:
-  if (is.null(connectionDetails$conn())) {
+  if (is.function(connectionDetails$conn)) {
+    conn <- connectionDetails$conn()
+  } else {
+    conn <- connectionDetails$conn
+  }
+
+  if (is.null(conn)) {
     conn <- DatabaseConnector::connect(connectionDetails)
   } else {
-    conn <- connectionDetails$conn()
+    closeConnection <- TRUE
   }
 
   DatabaseConnector::insertTable(connection = conn,
@@ -284,7 +291,7 @@ runSelfControlledCohort <- function(connectionDetails,
                                  targetDialect = connectionDetails$dbms,
                                  oracleTempSchema = oracleTempSchema)
   DatabaseConnector::executeSql(conn, sql, progressBar = FALSE, reportOverallTime = FALSE)
-  if (is.null(connectionDetails$conn())) {
+  if (closeConnection) {
     DatabaseConnector::disconnect(conn)
   }
   # estimates <- readRDS("s:/temp/estimates.rds")

--- a/R/SelfControlledCohort.R
+++ b/R/SelfControlledCohort.R
@@ -219,13 +219,9 @@ runSelfControlledCohort <- function(connectionDetails,
   }
 
   # Check if connection already open:
-  if (is.function(connectionDetails$conn)) {
-    conn <- connectionDetails$conn()
-  } else {
+  if (inherits(connectionDetails$conn, "DatabaseConnectorDbiConnection")) {
     conn <- connectionDetails$conn
-  }
-
-  if (is.null(conn)) {
+  } else {
     conn <- DatabaseConnector::connect(connectionDetails)
     on.exit(DatabaseConnector::disconnect(conn))
   }

--- a/R/SelfControlledCohort.R
+++ b/R/SelfControlledCohort.R
@@ -224,7 +224,7 @@ runSelfControlledCohort <- function(connectionDetails,
   }
 
   # Check if connection already open:
-  if ("conn"  %in% names(connectionDetails)) {
+  if ("conn" %in% names(connectionDetails)) {
     conn <- connectionDetails$conn
   } else {
     conn <- DatabaseConnector::connect(connectionDetails)
@@ -297,7 +297,6 @@ runSelfControlledCohort <- function(connectionDetails,
 
   # estimates <- readRDS("s:/temp/estimates.rds")
   # estimates <- estimates[1:100000, ]
-
   if (nrow(estimates) > 0) {
     ParallelLogger::logInfo("Computing incidence rate ratios and exact confidence intervals")
     zeroCountIdx <- estimates$numOutcomesExposed == 0 & estimates$numOutcomesUnexposed == 0

--- a/R/SelfControlledCohort.R
+++ b/R/SelfControlledCohort.R
@@ -224,7 +224,7 @@ runSelfControlledCohort <- function(connectionDetails,
   }
 
   # Check if connection already open:
-  if (inherits(connectionDetails$conn, "DatabaseConnectorDbiConnection")) {
+  if ("conn"  %in% names(connectionDetails)) {
     conn <- connectionDetails$conn
   } else {
     conn <- DatabaseConnector::connect(connectionDetails)

--- a/R/SelfControlledCohort.R
+++ b/R/SelfControlledCohort.R
@@ -218,7 +218,6 @@ runSelfControlledCohort <- function(connectionDetails,
     outcomePersonId <- "subject_id"
   }
 
-  closeConnection <- FALSE
   # Check if connection already open:
   if (is.function(connectionDetails$conn)) {
     conn <- connectionDetails$conn()
@@ -228,7 +227,7 @@ runSelfControlledCohort <- function(connectionDetails,
 
   if (is.null(conn)) {
     conn <- DatabaseConnector::connect(connectionDetails)
-    closeConnection <- TRUE
+    on.exit(DatabaseConnector::disconnect(conn))
   }
 
   DatabaseConnector::insertTable(connection = conn,
@@ -290,9 +289,7 @@ runSelfControlledCohort <- function(connectionDetails,
                                  targetDialect = connectionDetails$dbms,
                                  oracleTempSchema = oracleTempSchema)
   DatabaseConnector::executeSql(conn, sql, progressBar = FALSE, reportOverallTime = FALSE)
-  if (closeConnection) {
-    DatabaseConnector::disconnect(conn)
-  }
+
   # estimates <- readRDS("s:/temp/estimates.rds")
   # estimates <- estimates[1:100000, ]
 

--- a/R/SelfControlledCohort.R
+++ b/R/SelfControlledCohort.R
@@ -228,7 +228,6 @@ runSelfControlledCohort <- function(connectionDetails,
 
   if (is.null(conn)) {
     conn <- DatabaseConnector::connect(connectionDetails)
-  } else {
     closeConnection <- TRUE
   }
 


### PR DESCRIPTION
I think this is needed, the current supported version of DatabaseConnector is 2.0.0. Without this we will only be able to support DatabaseConnector > version 4.0.0.